### PR TITLE
Adding support for multiline log statements

### DIFF
--- a/beater/convert.go
+++ b/beater/convert.go
@@ -29,7 +29,8 @@ import (
 // - remove underscores from the beginning of fields as they are reserved in
 //   ElasticSearch for metadata information
 // - fields that can be converted to numbers, will be converted to numbers
-func MapStrFromJournalEntry(ev *sdjournal.JournalEntry, cleanKeys bool, convertToNumbers bool, MoveMetadataLocation string) common.MapStr {
+func MapStrFromJournalEntry(ev *sdjournal.JournalEntry, cleanKeys bool, convertToNumbers bool,
+				MoveMetadataLocation string, whitelistedFields []string) common.MapStr {
 	m := common.MapStr{}
 	// for the sake of MoveMetadataLocation we will write all the JournalEntry data except the "message" here
 	target := m
@@ -44,15 +45,17 @@ func MapStrFromJournalEntry(ev *sdjournal.JournalEntry, cleanKeys bool, convertT
 	}
 
 	// range over the JournalEntry Fields and convert to the common.MapStr
-	for k, v := range ev.Fields {
+	for k := range whitelistedFields {
 		nk := makeNewKey(k, cleanKeys)
-		nv := makeNewValue(v, convertToNumbers)
-		// message Field should be on the top level of the event
-		if nk == "message" {
-			m[nk] = nv
-			continue
+		if v, ok := ev.Fields[k]; ok {
+			nv := makeNewValue(v, convertToNumbers)
+			// message Field should be on the top level of the event
+			if nk == "message" {
+				m[nk] = nv
+				continue
+			}
+			target[nk] = nv
 		}
-		target[nk] = nv
 	}
 
 	return m

--- a/beater/convert.go
+++ b/beater/convert.go
@@ -30,7 +30,7 @@ import (
 //   ElasticSearch for metadata information
 // - fields that can be converted to numbers, will be converted to numbers
 func MapStrFromJournalEntry(ev *sdjournal.JournalEntry, cleanKeys bool, convertToNumbers bool,
-				MoveMetadataLocation string, whitelistedFields []string) common.MapStr {
+	MoveMetadataLocation string, whitelistedFields []string) common.MapStr {
 	m := common.MapStr{}
 	// for the sake of MoveMetadataLocation we will write all the JournalEntry data except the "message" here
 	target := m

--- a/config/config.go
+++ b/config/config.go
@@ -35,6 +35,7 @@ type Config struct {
 	MoveMetadataLocation string        `config:"move_metadata_to_field"`
 	DefaultType          string        `config:"default_type"`
 	Units                []string      `config:"units"`
+	FlushLogInterval     time.Duration `config:"flush_log_interval"`
 }
 
 // Named constants for the journal cursor placement positions
@@ -65,6 +66,7 @@ var (
 		CursorFlushPeriod:  5 * time.Second,
 		CursorSeekFallback: SeekPositionTail,
 		DefaultType:        "journal",
+		FlushLogInterval:   30 * time.Second,
 	}
 )
 


### PR DESCRIPTION
Any line which starts with space or tab is considered to be a continuation of the previous line. This should suffice for now. If we do not see any other log statements for the next 30 seconds (default value) for the same container or system daemon we will flush the logs. This is the flush_log_interval configuration in the yaml file.

Additionally I have picked out the fields from the journald logs which I thought were most relevant for us in terms of what we want to send to elastic search.