### PR TITLE
Aggregator log fanout

### DIFF
--- a/beater/journalbeat.go
+++ b/beater/journalbeat.go
@@ -406,5 +406,4 @@ func (jb *Journalbeat) Stop() {
 	for i := 0; i < jb.numLogstashAvailable; i++ {
 		jb.logstashClients[i].Close()
 	}
-	jb.logstashClients[0].Close()
 }


### PR DESCRIPTION
Since we are writing the logs to files we are not able to use the round-robin load balancing which journal beat provides out of the box because it is possible that logs for a single container or process might go to multiple log stash aggregator instances.

Instead we will be creating multiple pipelines to send messages to different log stash instances. For any given container/process we will map all its logs to one of these pipelines.