### PR TITLE
Shard by container_tag and shard on more send paths

### DIFF
--- a/main.go
+++ b/main.go
@@ -22,7 +22,7 @@ import (
 )
 
 func main() {
-	err := beat.Run("journalbeat", "5.0.1", beater.New)
+	err := beat.Run("journalbeat", "5.0.2", beater.New)
 	if err != nil {
 		log.Fatal(err)
 	}


### PR DESCRIPTION
Sharding is now by, in order of preference:
 - container_tag
 - logbuffer type (This is what journalbeat does assembly by)
 - type (container, docker, syslog, kernel, etc)

The list of receivers are now cyclically shifted left by client number. In order for pinning to shard to have any effect, journalbeat needs to be run with loadbalance: false.