### PR TITLE
Fix null syslog identifier and boolean cast

### DIFF
--- a/beater/convert.go
+++ b/beater/convert.go
@@ -46,12 +46,12 @@ func MapStrFromJournalEntry(ev *sdjournal.JournalEntry, cleanKeys bool, convertT
 	// range over the JournalEntry Fields and convert to the common.MapStr
 	for k, v := range ev.Fields {
 		nk := makeNewKey(k, cleanKeys)
-		nv := makeNewValue(v, convertToNumbers)
-		// message Field should be on the top level of the event
+		// message Field should be on the top level of the event and is kept as string
 		if nk == "message" {
-			m[nk] = nv
+			m[nk] = v
 			continue
 		}
+		nv := makeNewValue(v, convertToNumbers)
 		target[nk] = nv
 	}
 

--- a/beater/convert_test.go
+++ b/beater/convert_test.go
@@ -1,0 +1,19 @@
+package beater
+
+import (
+	"github.com/coreos/go-systemd/sdjournal"
+	"github.com/elastic/beats/libbeat/common"
+	"testing"
+)
+
+func TestGivenAJournalEntryWithABooleanStringWhenConvertingThenItShouldNotBeCastedToBool(t *testing.T) {
+	var journalEntryFields map[string]string = make(map[string]string)
+	journalEntryFields["message"] = "true"
+	var journalEntry sdjournal.JournalEntry = sdjournal.JournalEntry{Fields: journalEntryFields}
+
+	var mappedJournalEntry common.MapStr = MapStrFromJournalEntry(&journalEntry, false, false, "")
+
+	if mappedJournalEntry["message"] != "true" {
+		t.Errorf("Error! 'message' field shoud not have been casted")
+	}
+}

--- a/beater/extension_test.go
+++ b/beater/extension_test.go
@@ -1,20 +1,20 @@
 package beater
 
 import (
-	"testing"
-	"github.com/elastic/beats/libbeat/common"
 	"github.com/coreos/go-systemd/sdjournal"
+	"github.com/elastic/beats/libbeat/common"
+	"testing"
 )
 
 func TestGivenAJournalEntryWithoutContainerIdAndSyslogIdentifierWhenSendingItShouldBeIgnored(t *testing.T) {
 	var journalEntry common.MapStr = common.MapStr{}
 	var rawJournalEntry sdjournal.JournalEntry = sdjournal.JournalEntry{}
 	var incomingLogEvents chan common.MapStr = make(chan common.MapStr, 1)
-	journalEntry["pid"] = 42;
-	journalEntry["syslog_identifier"] = nil;
+	journalEntry["pid"] = 42
+	journalEntry["syslog_identifier"] = nil
 	var jb *Journalbeat = &Journalbeat{
 		JournalBeatExtension: &JournalBeatExtension{
-			metrics: &JournalBeatMetrics{},
+			metrics:           &JournalBeatMetrics{},
 			incomingLogEvents: incomingLogEvents,
 		},
 	}

--- a/beater/extension_test.go
+++ b/beater/extension_test.go
@@ -6,18 +6,12 @@ import (
 	"testing"
 )
 
-func TestGivenAJournalEntryWithoutContainerIdAndSyslogIdentifierWhenSendingItShouldBeIgnored(t *testing.T) {
-	var journalEntry common.MapStr = common.MapStr{}
+func TestGivenAJournalEntryWithoutContainerIdAndNoSyslogIdentifierWhenTryingToSendItShouldBeIgnored(t *testing.T) {
 	var rawJournalEntry sdjournal.JournalEntry = sdjournal.JournalEntry{}
+	var journalEntry common.MapStr = common.MapStr{}
+	journalEntry["pid"] = "42"
 	var incomingLogEvents chan common.MapStr = make(chan common.MapStr, 1)
-	journalEntry["pid"] = 42
-	var jb *Journalbeat = &Journalbeat{
-		JournalBeatExtension: &JournalBeatExtension{
-			metrics:           &JournalBeatMetrics{},
-			incomingLogEvents: incomingLogEvents,
-		},
-	}
-	jb.metrics.init(false, "")
+	var jb *Journalbeat = createJournalBeatWithIncomingLogEventsChannel(incomingLogEvents)
 
 	jb.sendEvent(journalEntry, &rawJournalEntry)
 
@@ -26,4 +20,16 @@ func TestGivenAJournalEntryWithoutContainerIdAndSyslogIdentifierWhenSendingItSho
 		t.Errorf("Error! No events should have been sent to 'incomingLogEvents' channel")
 	default:
 	}
+}
+
+// creates a Journalbeat object with the given channel in order to check interactions with it
+func createJournalBeatWithIncomingLogEventsChannel(incomingLogEvents chan common.MapStr) *Journalbeat {
+	var jb *Journalbeat = &Journalbeat{
+		JournalBeatExtension: &JournalBeatExtension{
+			metrics:           &JournalBeatMetrics{},
+			incomingLogEvents: incomingLogEvents,
+		},
+	}
+	jb.metrics.init(false, "")
+	return jb
 }

--- a/beater/extension_test.go
+++ b/beater/extension_test.go
@@ -11,7 +11,6 @@ func TestGivenAJournalEntryWithoutContainerIdAndSyslogIdentifierWhenSendingItSho
 	var rawJournalEntry sdjournal.JournalEntry = sdjournal.JournalEntry{}
 	var incomingLogEvents chan common.MapStr = make(chan common.MapStr, 1)
 	journalEntry["pid"] = 42
-	journalEntry["syslog_identifier"] = nil
 	var jb *Journalbeat = &Journalbeat{
 		JournalBeatExtension: &JournalBeatExtension{
 			metrics:           &JournalBeatMetrics{},
@@ -26,17 +25,5 @@ func TestGivenAJournalEntryWithoutContainerIdAndSyslogIdentifierWhenSendingItSho
 	case <-incomingLogEvents:
 		t.Errorf("Error! No events should have been sent to 'incomingLogEvents' channel")
 	default:
-	}
-}
-
-func TestGivenAJournalEntryWithABooleanStringWhenConvertingThenItShouldNotBeCastedToBool(t *testing.T) {
-	var journalEntryFields map[string]string = make(map[string]string)
-	journalEntryFields["message"] = "true"
-	var journalEntry sdjournal.JournalEntry = sdjournal.JournalEntry{Fields: journalEntryFields}
-
-	var mappedJournalEntry common.MapStr = MapStrFromJournalEntry(&journalEntry, false, false, "")
-
-	if mappedJournalEntry["message"] != "true" {
-		t.Errorf("Error! 'message' field shoud not have been casted")
 	}
 }

--- a/beater/extension_test.go
+++ b/beater/extension_test.go
@@ -24,7 +24,19 @@ func TestGivenAJournalEntryWithoutContainerIdAndSyslogIdentifierWhenSendingItSho
 
 	select {
 	case <-incomingLogEvents:
-		t.Errorf("Error! no events should have been sent to 'incomingLogEvents' channel")
+		t.Errorf("Error! No events should have been sent to 'incomingLogEvents' channel")
 	default:
+	}
+}
+
+func TestGivenAJournalEntryWithABooleanStringWhenConvertingThenItShouldNotBeCastedToBool(t *testing.T) {
+	var journalEntryFields map[string]string = make(map[string]string)
+	journalEntryFields["message"] = "true"
+	var journalEntry sdjournal.JournalEntry = sdjournal.JournalEntry{Fields: journalEntryFields}
+
+	var mappedJournalEntry common.MapStr = MapStrFromJournalEntry(&journalEntry, false, false, "")
+
+	if mappedJournalEntry["message"] != "true" {
+		t.Errorf("Error! 'message' field shoud not have been casted")
 	}
 }

--- a/beater/extension_test.go
+++ b/beater/extension_test.go
@@ -1,0 +1,30 @@
+package beater
+
+import (
+	"testing"
+	"github.com/elastic/beats/libbeat/common"
+	"github.com/coreos/go-systemd/sdjournal"
+)
+
+func TestGivenAJournalEntryWithoutContainerIdAndSyslogIdentifierWhenSendingItShouldBeIgnored(t *testing.T) {
+	var journalEntry common.MapStr = common.MapStr{}
+	var rawJournalEntry sdjournal.JournalEntry = sdjournal.JournalEntry{}
+	var incomingLogEvents chan common.MapStr = make(chan common.MapStr, 1)
+	journalEntry["pid"] = 42;
+	journalEntry["syslog_identifier"] = nil;
+	var jb *Journalbeat = &Journalbeat{
+		JournalBeatExtension: &JournalBeatExtension{
+			metrics: &JournalBeatMetrics{},
+			incomingLogEvents: incomingLogEvents,
+		},
+	}
+	jb.metrics.init(false, "")
+
+	jb.sendEvent(journalEntry, &rawJournalEntry)
+
+	select {
+	case <-incomingLogEvents:
+		t.Errorf("Error! no events should have been sent to 'incomingLogEvents' channel")
+	default:
+	}
+}


### PR DESCRIPTION
This PR fixes the following issues:
1. Log events with a message equal to a string that was mapped to boolean would later on fail when being cast to string
2. Log events with no container tag and syslog identifier would crash when being sent to logstash